### PR TITLE
Update links from 2.6.1 to 2.6.2 and 2.7 alpha to 2.7 beta

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -70,11 +70,11 @@ d.each{|kvp| <span class="keyword">puts</span> kvp}""",
   'ironpython': {
     'language': 'Python',
     'language_website': 'http://python.org',
-    'stable_version': '2.6.1',
-    'stable_release_url': 'http://ironpython.codeplex.com/releases/view/36280#DownloadId=116507',
-    'stable_release_date': '2.6.1 released on 2010-04-12',
-    'stable_release_notes': 'http://ironpython.codeplex.com/releases/view/36280',
-    'stable_release_source': 'http://ironpython.codeplex.com/releases/view/36280#DownloadId=116511',
+    'stable_version': '2.6.2',
+    'stable_release_url': 'http://ironpython.codeplex.com/releases/view/41236#DownloadId=159515',
+    'stable_release_date': '2.6.2 released on 2010-10-21',
+    'stable_release_notes': 'http://ironpython.codeplex.com/releases/view/41236',
+    'stable_release_source': 'http://ironpython.codeplex.com/releases/view/41236#DownloadId=159516',
     'code_snippet_html': """<img src="../images/ironpython-interactive.png" height="279" alt="IronPython Interactive in Visual Studio 2010" />""",
     'old_code_snippet_html': """<span class="comment"># namespaces are modules</span>
 <span class="keyword">from</span> <span class="constant">System</span>.<span class="constant">Collections</span>.<span class="constant">Generic</span> import <span class="constant">Dictionary</span>

--- a/python/announcements/index.rst
+++ b/python/announcements/index.rst
@@ -2,6 +2,23 @@
 Announcements
 =============
 
+.. admonition:: January 10, 2011
+   :class: strip
+
+   `Dino Viehland <http://blogs.msdn.com/b/dinoviehland/>`_ is set to be involved in the 
+   `Python VMs <http://us.pycon.org/2011/schedule/sessions/14/>`_
+   panel discussion at PyCon this year. Be sure to check it out if you're going.
+
+.. admonition:: October 21, 2010
+   :class: strip
+
+   `IronPython 2.6.2 Final <http://ironpython.codeplex.com/releases/view/41236>`_
+   was released, with a few minor bugfixes, supporting both .NET 2.0 SP1 and .NET 4.0 RTM.
+   
+   `IronPython 2.7 Beta 1 <http://ironpython.codeplex.com/releases/view/48818>`_
+   was released for .NET 4, supporting Python 2.7 features and improving on 
+   Visual Studio 2010 support.
+
 .. admonition:: July 16, 2010
    :class: strip
 

--- a/python/documentation/index.rst
+++ b/python/documentation/index.rst
@@ -74,7 +74,7 @@ Samples
 Source Code
 -----------
 When all else fails, you can always look at the 
-`IronPython source code <http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx>`_
+`IronPython source code <https://github.com/IronLanguages/main>`_
 
 
 --------------

--- a/python/download/index.rst
+++ b/python/download/index.rst
@@ -7,8 +7,8 @@ Get IronPython
 Stable versions
 ---------------
 IronPython maintains compatible versions with `Python 2.5`_ and `Python 2.6`_;
-`IronPython 2.0.3`_ and `IronPython 2.6.1`_, respectively. If you're not sure
-which version to use, use `IronPython 2.6.1`_.
+`IronPython 2.0.3`_ and `IronPython 2.6.2`_, respectively. If you're not sure
+which version to use, use `IronPython 2.6.2`_.
 
 `All major IronPython releases`_
 
@@ -16,12 +16,12 @@ which version to use, use `IronPython 2.6.1`_.
 --------------
 Latest version
 --------------
-The latest version of IronPython is `IronPython 2.7 Alpha 1`_, which is
+The latest version of IronPython is `IronPython 2.7 Beta 1`_, which is
 tracking compatibility with `Python 2.7`_.
 
 .. container:: download col
    
-   `Download IronPython 2.7 Alpha 1`_
+   `Download IronPython 2.7 Beta 1`_
 
 
 -----------
@@ -31,13 +31,11 @@ IronPython is an `open source project`_ freely available under the `Apache Licen
 
 .. container:: download col
    
-   `Download IronPython 2.7 Alpha 1 Source Code`_
-   
-   `Download IronPython 2.6.1 Source Code`_
+   `Download IronPython 2.6.2 Source Code`_
 
 `Download latest (zip)`_ | `Browse Online`_ | `Recent Check-ins`_
 
-`Instructions for accessing with SVN or TFS`_
+`Instructions for accessing with Git`_
 
 .. container:: divider
 
@@ -97,7 +95,7 @@ Mac OS & Linux desktop & server apps
 
    .. container:: download
 
-      `Latest Mono version (2.6.4)`_
+      `Latest Mono version (2.8.2)`_
 
 Linux browser apps
 ~~~~~~~~~~~~~~~~~~
@@ -108,7 +106,7 @@ Linux browser apps
 
    .. container:: download
 
-      `Latest Moonlight version (2.0)`_
+      `Moonlight version (2.0)`_
 
 
    .. note::
@@ -124,18 +122,17 @@ Linux browser apps
 .. _Python 2.6:       http://www.python.org/download/releases/2.6/
 .. _Python 2.7:       http://www.python.org/download/releases/2.7/
 .. _IronPython 2.0.3: http://ironpython.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=30416
-.. _IronPython 2.6.1:   http://ironpython.codeplex.com/releases/view/36280
-.. _IronPython 2.7 Alpha 1:   http://ironpython.codeplex.com/releases/view/42434
-.. _Download IronPython 2.7 Alpha 1: http://ironpython.codeplex.com/releases/view/42434
+.. _IronPython 2.6.2:   http://ironpython.codeplex.com/releases/view/41236
+.. _IronPython 2.7 Beta 1:   http://ironpython.codeplex.com/releases/view/48818
+.. _Download IronPython 2.7 Beta 1: http://ironpython.codeplex.com/releases/view/48818#DownloadId=159517
 .. _All major IronPython releases: http://ironpython.codeplex.com/wikipage?title=SupportedReleaseList
 .. _open source project: http://ironpython.codeplex.com
 .. _Apache License (Version 2): http://ironpython.codeplex.com/license
-.. _Download IronPython 2.6.1 Source Code: http://ironpython.codeplex.com/releases/view/36280#DownloadId=116511
-.. _Download IronPython 2.7 Alpha 1 Source Code: http://ironpython.codeplex.com/releases/view/42434#DownloadId=133181
-.. _Download latest (zip): http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx#DownloadLatest
-.. _Browse Online: http://ironpython.codeplex.com/SourceControl/BrowseLatest
-.. _Recent Check-ins: http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx
-.. _Instructions for accessing with SVN or TFS: http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx
+.. _Download IronPython 2.6.2 Source Code: http://ironpython.codeplex.com/releases/view/41236#DownloadId=159516
+.. _Download latest (zip): https://github.com/IronLanguages/main
+.. _Browse Online: https://github.com/IronLanguages/main
+.. _Recent Check-ins: https://github.com/IronLanguages/main/commits/master
+.. _Instructions for accessing with Git: https://github.com/IronLanguages/main/wiki/Getting-the-sources
 .. _Latest .NET version (4.0): http://bit.ly/iron-dotnet40
 .. _4.0: http://bit.ly/iron-dotnet40
 .. _3.5 SP1: http://bit.ly/iron-dotnet35sp1
@@ -145,6 +142,6 @@ Linux browser apps
 .. _Latest Silverlight version (4.0): http://go.microsoft.com/fwlink/?linkid=150228
 .. _Learn more about Python in the browser: ../browser/
 .. _Mono: http://www.mono-project.com
-.. _Latest Mono version (2.6.4): http://www.go-mono.com/mono-downloads/download.html
+.. _Latest Mono version (2.8.2): http://www.go-mono.com/mono-downloads/download.html
 .. _Moonlight: http://www.mono-project.com/Moonlight
-.. _Latest Moonlight version (2.0): http://go-mono.com/moonlight-beta
+.. _Moonlight version (2.0): http://go-mono.com/moonlight-beta

--- a/python/index.rst
+++ b/python/index.rst
@@ -16,6 +16,23 @@ developers an amazing amount of functionality and power.
 Announcements
 -------------
 
+.. admonition:: January 10, 2011
+   :class: strip
+
+   `Dino Viehland <http://blogs.msdn.com/b/dinoviehland/>`_ is set to be involved in the 
+   `Python VMs <http://us.pycon.org/2011/schedule/sessions/14/>`_
+   panel discussion at PyCon this year. Be sure to check it out if you're going.
+
+.. admonition:: October 21, 2010
+   :class: strip
+
+   `IronPython 2.6.2 Final <http://ironpython.codeplex.com/releases/view/41236>`_
+   was released, with a few minor bugfixes, supporting both .NET 2.0 SP1 and .NET 4.0 RTM.
+   
+   `IronPython 2.7 Beta 1 <http://ironpython.codeplex.com/releases/view/48818>`_
+   was released for .NET 4, supporting Python 2.7 features and improving on 
+   Visual Studio 2010 support.
+
 .. admonition:: July 16, 2010
    :class: strip
 

--- a/python/support/index.rst
+++ b/python/support/index.rst
@@ -31,11 +31,6 @@ See the `FAQ <http://ironpython.codeplex.com/wikipage?title=FAQ>`_
 for common questions about IronPython, like *When will Python support be added into Visual Studio*,
 and various .NET interop and compatibility questions.
       
-------------
-Project Info
-------------
-`2.6 Release Plan <http://ironpython.codeplex.com/wikipage?title=2.6%20Release%20Plan">`_
-
 ------------------
 Articles and Blogs
 ------------------

--- a/python/tools/download/index.html
+++ b/python/tools/download/index.html
@@ -12,7 +12,7 @@
 <h1>Downloading IronPython Tools for Visual Studio (CTP3)</h1>
 
 <p>
-  <a href="http://ironpython.codeplex.com/releases/view/42434#DownloadId=133184">Click here if your download does not start immediately.</a>
+  <a href="http://ironpython.codeplex.com/releases/view/48818#DownloadId=159517">Click here if your download does not start immediately.</a>
 </p>
 
 <script type="text/javascript">
@@ -27,6 +27,6 @@ var pageTracker = _gat._getTracker("UA-16148811-1");
 <script type="text/javascript">
 pageTracker._trackPageview('/download/tools-ctp4');
 </script>
-<meta http-equiv="REFRESH" content="0;url=http://ironpython.codeplex.com/releases/view/42434#DownloadId=133184">
+<meta http-equiv="REFRESH" content="0;url=http://ironpython.codeplex.com/releases/view/48818#DownloadId=159517">
 </BODY>
 </HTML>

--- a/python/tools/download/versions.html
+++ b/python/tools/download/versions.html
@@ -10,7 +10,8 @@
 </p>
 
 <ul>
-  <li><a href="http://ironpython.codeplex.com/releases/view/42434">Download IronPython Tools for Visual Studio (CTP4)</a></li>
+  <li><a href="http://ironpython.codeplex.com/releases/view/48818">Download IronPython Tools for Visual Studio (CTP5)</a></li>
+  <li><a href="ctp4/">Download IronPython Tools for Visual Studio (CTP4)</a></li>
   <li><a href="ctp3/">Download IronPython Tools for Visual Studio (CTP3)</a></li>
   <li><a href="ctp2/">Download IronPython Tools for Visual Studio (CTP2)</a></li>
 </ul>


### PR DESCRIPTION
I updated (hopefully) all the links that were pointing at the 2.6.1 stable version to the 2.6.2 stable version. I also updated all the links that pointed at the 2.7 alpha to the 2.7 beta. Hopeully this will deal with some of the confusion ([mailing list](http://lists.ironpython.com/pipermail/users-ironpython.com/2010-December/014068.html), [stackoverflow](http://programmers.stackexchange.com/questions/38111/ironpython-effectively-dead)) that some of this causes. 

I've deleted some bits that don't seem relevant namely:
- No place to get the IronPython 2.7 Beta 1 sources
- Deleted the section that had the 2.6 release plan. It no longer exists on Codeplex and there's no replacement for 2.7

I looked at the NEWRELEASE.rst and it said to update the versions.html file which I've done. I've just called it CTP 5 in line with what's already there but I'm not sure if that's correct.

I've also added some announcements. Have a look and see if you agree with them. I just wanted to make the site look a bit more current.
