### PR TITLE
Add latest IronPython releases to the website

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -70,11 +70,11 @@ d.each{|kvp| <span class="keyword">puts</span> kvp}""",
   'ironpython': {
     'language': 'Python',
     'language_website': 'http://python.org',
-    'stable_version': '2.6.1',
-    'stable_release_url': 'http://ironpython.codeplex.com/releases/view/36280#DownloadId=116507',
-    'stable_release_date': '2.6.1 released on 2010-04-12',
+    'stable_version': '2.6.2',
+    'stable_release_url': 'http://ironpython.codeplex.com/releases/view/41236#DownloadId=159515',
+    'stable_release_date': '2.6.2 released on 2010-10-21',
     'stable_release_notes': 'http://ironpython.codeplex.com/releases/view/36280',
-    'stable_release_source': 'http://ironpython.codeplex.com/releases/view/36280#DownloadId=116511',
+    'stable_release_source': 'http://ironpython.codeplex.com/releases/view/41236#DownloadId=159516',
     'code_snippet_html': """<img src="../images/ironpython-interactive.png" height="279" alt="IronPython Interactive in Visual Studio 2010" />""",
     'old_code_snippet_html': """<span class="comment"># namespaces are modules</span>
 <span class="keyword">from</span> <span class="constant">System</span>.<span class="constant">Collections</span>.<span class="constant">Generic</span> import <span class="constant">Dictionary</span>

--- a/python/announcements/index.rst
+++ b/python/announcements/index.rst
@@ -5,6 +5,12 @@ Announcements
 .. admonition:: October 21, 2010
    :class: strip
 
+   `IronPython 2.7 Beta 1 <http://ironpython.codeplex.com/releases/view/48818>`_
+   was released.
+
+.. admonition:: October 21, 2010
+   :class: strip
+
    `IronPython 2.6.2  <http://ironpython.codeplex.com/releases/view/41236>`_
    was released, supporting both .NET 2.0 SP1 and .NET 4. This is a minor 
    update which fixes the most egregious issues discovered since 2.6.1. 

--- a/python/announcements/index.rst
+++ b/python/announcements/index.rst
@@ -2,6 +2,13 @@
 Announcements
 =============
 
+.. admonition:: October 21, 2010
+   :class: strip
+
+   `IronPython 2.6.2  <http://ironpython.codeplex.com/releases/view/41236>`_
+   was released, supporting both .NET 2.0 SP1 and .NET 4. This is a minor 
+   update which fixes the most egregious issues discovered since 2.6.1. 
+
 .. admonition:: July 16, 2010
    :class: strip
 

--- a/python/download/index.rst
+++ b/python/download/index.rst
@@ -16,12 +16,12 @@ which version to use, use `IronPython 2.6.2`_.
 --------------
 Latest version
 --------------
-The latest version of IronPython is `IronPython 2.7 Alpha 1`_, which is
+The latest version of IronPython is `IronPython 2.7 Beta 1`_, which is
 tracking compatibility with `Python 2.7`_.
 
 .. container:: download col
    
-   `Download IronPython 2.7 Alpha 1`_
+   `Download IronPython 2.7 Beta 1`_
 
 
 -----------
@@ -31,7 +31,7 @@ IronPython is an `open source project`_ freely available under the `Apache Licen
 
 .. container:: download col
    
-   `Download IronPython 2.7 Alpha 1 Source Code`_
+   `Download IronPython 2.7 Beta 1 Source Code`_
    
    `Download IronPython 2.6.2 Source Code`_
 
@@ -125,13 +125,13 @@ Linux browser apps
 .. _Python 2.7:       http://www.python.org/download/releases/2.7/
 .. _IronPython 2.0.3: http://ironpython.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=30416
 .. _IronPython 2.6.2:   http://ironpython.codeplex.com/releases/view/41236
-.. _IronPython 2.7 Alpha 1:   http://ironpython.codeplex.com/releases/view/42434
-.. _Download IronPython 2.7 Alpha 1: http://ironpython.codeplex.com/releases/view/42434
+.. _IronPython 2.7 Beta 1:   http://ironpython.codeplex.com/releases/view/48818
+.. _Download IronPython 2.7 Beta 1: http://ironpython.codeplex.com/releases/view/48818#DownloadId=159517
 .. _All major IronPython releases: http://ironpython.codeplex.com/wikipage?title=SupportedReleaseList
 .. _open source project: http://ironpython.codeplex.com
 .. _Apache License (Version 2): http://ironpython.codeplex.com/license
 .. _Download IronPython 2.6.2 Source Code: http://ironpython.codeplex.com/releases/view/41236#DownloadId=159516
-.. _Download IronPython 2.7 Alpha 1 Source Code: http://ironpython.codeplex.com/releases/view/42434#DownloadId=133181
+.. _Download IronPython 2.7 Beta 1 Source Code: http://ironpython.codeplex.com/releases/view/48818
 .. _Download latest (zip): http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx#DownloadLatest
 .. _Browse Online: http://ironpython.codeplex.com/SourceControl/BrowseLatest
 .. _Recent Check-ins: http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx

--- a/python/download/index.rst
+++ b/python/download/index.rst
@@ -7,8 +7,8 @@ Get IronPython
 Stable versions
 ---------------
 IronPython maintains compatible versions with `Python 2.5`_ and `Python 2.6`_;
-`IronPython 2.0.3`_ and `IronPython 2.6.1`_, respectively. If you're not sure
-which version to use, use `IronPython 2.6.1`_.
+`IronPython 2.0.3`_ and `IronPython 2.6.2`_, respectively. If you're not sure
+which version to use, use `IronPython 2.6.2`_.
 
 `All major IronPython releases`_
 
@@ -33,7 +33,7 @@ IronPython is an `open source project`_ freely available under the `Apache Licen
    
    `Download IronPython 2.7 Alpha 1 Source Code`_
    
-   `Download IronPython 2.6.1 Source Code`_
+   `Download IronPython 2.6.2 Source Code`_
 
 `Download latest (zip)`_ | `Browse Online`_ | `Recent Check-ins`_
 
@@ -124,13 +124,13 @@ Linux browser apps
 .. _Python 2.6:       http://www.python.org/download/releases/2.6/
 .. _Python 2.7:       http://www.python.org/download/releases/2.7/
 .. _IronPython 2.0.3: http://ironpython.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=30416
-.. _IronPython 2.6.1:   http://ironpython.codeplex.com/releases/view/36280
+.. _IronPython 2.6.2:   http://ironpython.codeplex.com/releases/view/41236
 .. _IronPython 2.7 Alpha 1:   http://ironpython.codeplex.com/releases/view/42434
 .. _Download IronPython 2.7 Alpha 1: http://ironpython.codeplex.com/releases/view/42434
 .. _All major IronPython releases: http://ironpython.codeplex.com/wikipage?title=SupportedReleaseList
 .. _open source project: http://ironpython.codeplex.com
 .. _Apache License (Version 2): http://ironpython.codeplex.com/license
-.. _Download IronPython 2.6.1 Source Code: http://ironpython.codeplex.com/releases/view/36280#DownloadId=116511
+.. _Download IronPython 2.6.2 Source Code: http://ironpython.codeplex.com/releases/view/41236#DownloadId=159516
 .. _Download IronPython 2.7 Alpha 1 Source Code: http://ironpython.codeplex.com/releases/view/42434#DownloadId=133181
 .. _Download latest (zip): http://ironpython.codeplex.com/SourceControl/ListDownloadableCommits.aspx#DownloadLatest
 .. _Browse Online: http://ironpython.codeplex.com/SourceControl/BrowseLatest

--- a/python/index.rst
+++ b/python/index.rst
@@ -19,6 +19,12 @@ Announcements
 .. admonition:: October 21, 2010
    :class: strip
 
+   `IronPython 2.7 Beta 1 <http://ironpython.codeplex.com/releases/view/48818>`_
+   was released.
+
+.. admonition:: October 21, 2010
+   :class: strip
+
    `IronPython 2.6.2  <http://ironpython.codeplex.com/releases/view/41236>`_
    was released, supporting both .NET 2.0 SP1 and .NET 4. This is a minor 
    update which fixes the most egregious issues discovered since 2.6.1. 

--- a/python/index.rst
+++ b/python/index.rst
@@ -16,6 +16,13 @@ developers an amazing amount of functionality and power.
 Announcements
 -------------
 
+.. admonition:: October 21, 2010
+   :class: strip
+
+   `IronPython 2.6.2  <http://ironpython.codeplex.com/releases/view/41236>`_
+   was released, supporting both .NET 2.0 SP1 and .NET 4. This is a minor 
+   update which fixes the most egregious issues discovered since 2.6.1. 
+
 .. admonition:: July 16, 2010
    :class: strip
 


### PR DESCRIPTION
These commits update the website to show IronPython 2.6.2 and IronPython 2.7 Beta 1 as the latest releases.
